### PR TITLE
#3172038: Remove core Key

### DIFF
--- a/emulsify_twig.info.yml
+++ b/emulsify_twig.info.yml
@@ -1,7 +1,6 @@
 name: Emulsify Twig Extensions Module
 type: module
 description: BEM and Add Attributes Twig Extensions for Drupal
-core: 8.x
 core_version_requirement: ^8 || ^9
 version: 2.0.0
 package: Emulsify


### PR DESCRIPTION
see https://www.drupal.org/project/emulsify_twig/issues/3172038

## Problem/Motivation
When this module is installed every page presents a fatal.

  The 'core_version_requirement' constraint (^8.8 || ^9) requires the 'core' key not be set in profiles/contrib/sous/sous.info.yml 
This was introduced in 8.7.7. see the Change Log.

## Steps to reproduce
I just used sous-project to reproduce this...

Follow the install instructions here: https://github.com/fourkitchens/sous-drupal-project and run a `drush si sous` to see this error after the first page load.

## Proposed resolution
Since we require 8.8 or above, we need to remove the core key... keep in mind that requring 8.8 and above means that we cannot installl 2.0 (or higher) in older sites mandating an upgrade (which shouldn't be a big deal since we want to keep our sites secure).