### PR TITLE
1: check for null values in arrays

### DIFF
--- a/src/BemTwigExtension.php
+++ b/src/BemTwigExtension.php
@@ -63,7 +63,9 @@ class BemTwigExtension extends \Twig_Extension {
         // Set blockname--modifier classes for each modifier.
         if (!empty($modifiers)) {
           foreach ($modifiers as $modifier) {
-            $classes[] = $blockname . '__' . $base_class . '--' . $modifier;
+            if (!empty($modifier)) {
+              $classes[] = $blockname . '__' . $base_class . '--' . $modifier;
+            }
           };
         }
       }
@@ -74,14 +76,18 @@ class BemTwigExtension extends \Twig_Extension {
         // Set base--modifier class for each modifier.
         if (!empty($modifiers)) {
           foreach ($modifiers as $modifier) {
-            $classes[] = $base_class . '--' . $modifier;
+            if (!empty($modifier)) {
+              $classes[] = $base_class . '--' . $modifier;
+            }
           };
         }
       }
       // If extra non-BEM classes are added.
       if (!empty($extra)) {
         foreach ($extra as $extra_class) {
-          $classes[] = $extra_class;
+          if (!empty($extra)) {
+            $classes[] = $extra_class;
+          }
         };
       }
       if (class_exists('Drupal')) {


### PR DESCRIPTION
Not sure if this is the best way, but this addition fixes the issue of empty modifiers or extra classes (e.g.: `<div class="card__content card__content--">`

To Test:
- [ ] Run this branch of the module inside a Drupal installation and ensure it fixes the issues anywhere components are used and throws no errors. The homepage article view uses the card component if you need a quick test. Just publish some article content and verify the markup doesn't include those extra classes anymore on the homepage.
- [ ] Ensure code is correct.