### PR TITLE
fix: fixes non-existent modifiers from existing (so existential)

### DIFF
--- a/src/BemTwigExtension.php
+++ b/src/BemTwigExtension.php
@@ -63,7 +63,7 @@ class BemTwigExtension extends \Twig_Extension {
         // Set blockname--modifier classes for each modifier.
         if (!empty($modifiers)) {
           foreach ($modifiers as $modifier) {
-            if (!empty($modifier)) {
+            if (isset($modifier)) {
               $classes[] = $blockname . '__' . $base_class . '--' . $modifier;
             }
           };
@@ -76,7 +76,7 @@ class BemTwigExtension extends \Twig_Extension {
         // Set base--modifier class for each modifier.
         if (!empty($modifiers)) {
           foreach ($modifiers as $modifier) {
-            if (!empty($modifier)) {
+            if (isset($modifier)) {
               $classes[] = $base_class . '--' . $modifier;
             }
           };


### PR DESCRIPTION
**Summary**
This PR fixes/implements the following **bugs/features**

- Empty modifiers were being created on every `bem` function. For example: `<div class="layout layout-- layout--xl">` This fixes by checking to see if any array item actually exists (as in not empty).

**How to review this PR**
- [ ] Pull this branch down and clear the cache. Open a Drupal site and examine the class structure that gets used with the `bem` function. It should remove the empty modifiers like so:

![Screen Shot 2021-10-22 at 8 46 53 AM](https://user-images.githubusercontent.com/8405274/138455968-463959e8-69a9-43e9-8ffc-470dc6cb61e0.png)

I've verified locally it doesn't affect other class structures, but please check on your end as well.

**Closing issues**
This should resolve the PR and issue found over on the JS side of things: https://github.com/emulsify-ds/emulsify-twig-extensions/pull/1#issuecomment-943647408
