### PR TITLE
Resolve multiple problems with the BEM definition:

### DIFF
--- a/src/BemTwigExtension.php
+++ b/src/BemTwigExtension.php
@@ -85,28 +85,31 @@ class BemTwigExtension extends \Twig_Extension {
       // If extra non-BEM classes are added.
       if (!empty($extra)) {
         foreach ($extra as $extra_class) {
-          if (!empty($extra)) {
+          if (!empty($extra_class)) {
             $classes[] = $extra_class;
           }
         };
       }
       if (class_exists('Drupal')) {
         $attributes = new Attribute();
-        // Iterate the attributes available in context.
-        foreach($context['attributes'] as $key => $value) {
-          // If there are classes, add them to the classes array.
-          if ($key === 'class') {
-            foreach ($value as $class) {
-              $classes[] = $class;
+        // Checking the attributes from the context.
+        if (!empty($context['attributes'])) {
+          // Iterate the attributes available in context.
+          foreach($context['attributes'] as $key => $value) {
+            // If there are classes, add them to the classes array.
+            if ($key === 'class') {
+              foreach ($value as $class) {
+                $classes[] = $class;
+              }
             }
+            // Otherwise add the attribute straightaway.
+            else {
+              $attributes->setAttribute($key, $value);
+            }
+            // Remove the attribute from context so it doesn't trickle down to
+            // includes.
+            $context['attributes']->removeAttribute($key);
           }
-          // Otherwise add the attribute straightaway.
-          else {
-            $attributes->setAttribute($key, $value);
-          }
-          // Remove the attribute from context so it doesn't trickle down to
-          // includes.
-          $context['attributes']->removeAttribute($key);
         }
         // Add class attribute.
         if (!empty($classes)) {


### PR DESCRIPTION
* $context['attributes'] could be empty in some context
* Fixed typo for the non-BEM classes

**Summary**

1. While `bem` twig function is being used, an error appears when attributes is empty in context.

Error is:

```
Warning: Undefined array key "attributes" in Drupal\emulsify_twig\BemTwigExtension->bem() (line 96 of modules/contrib/emulsify_twig/src/BemTwigExtension.php).
Drupal\emulsify_twig\BemTwigExtension->bem(Array, 'class-name’) (Line: 42)
```

2. Fixed typo in the bem function which does not allow to add some non-BEM classes.

**How to review this PR**
<!-- Provide step-by-step instructions to functionally test this PR. -->
<!-- Ensure that your code passing the repo's linting standards. -->
- [ ] Create a template which does not have a “attributes” variable in context
- [ ] Include this template with the twig system
- [ ] Load the page
- [ ] Error appears