### PR TITLE
fix: pass any attribute value type to markup (part 2)

### DIFF
--- a/src/AddAttributesTwigExtension.php
+++ b/src/AddAttributesTwigExtension.php
@@ -35,27 +35,41 @@ class AddAttributesTwigExtension extends \Twig_Extension {
 
     if (!empty($additional_attributes)) {
       foreach ($additional_attributes as $key => $value) {
-        if (is_array($value)) {
-          foreach ($value as $index => $item) {
-            // Handle bem() output.
-            if ($item instanceof Attribute) {
-              // Remove the item.
-              unset($value[$index]);
-              $value = array_merge($value, $item->toArray()[$key]);
+
+        switch (gettype($value)) {
+          case 'array':
+            foreach ($value as $index => $item) {
+              // Handle bem() output.
+              if ($item instanceof Attribute) {
+                // Remove the item.
+                unset($value[$index]);
+                $value = array_merge($value, $item->toArray()[$key]);
+              }
             }
-          }
-        }
-        else {
-          // Handle bem() output.
-          if ($value instanceof Attribute) {
-            $value = $value->toArray()[$key];
-          }
-          elseif (is_string($value)) {
-            $value = [$value];
-          }
-          else {
-            continue;
-          }
+            break;
+
+          case 'integer':
+          case 'boolean':
+          case 'string':
+            // Handle bem() output.
+            if ($value instanceof Attribute) {
+              $value = $value->toArray()[$key];
+            }
+            else {
+              $value = [strval($value)];
+            }
+            break;
+
+          case 'object':
+            if ($value instanceof Attribute) {
+              $value = $value->toArray()[$key];
+            }
+            break;
+
+          default:
+            // Set value to an empty string.
+            $value = '';
+            break;
         }
         // Merge additional attribute values with existing ones.
         if ($context['attributes']->offsetExists($key)) {


### PR DESCRIPTION
**Summary**
- Related PR for npm package - https://github.com/emulsify-ds/emulsify-twig-extensions/pull/6 
- https://github.com/emulsify-ds/emulsify-twig-extensions/issues/4

This PR fixes/implements the following **bugs/features**
- Allow for non-string values to be passed to the `add_attributes` function within a Drupal twig template

Explain the **motivation** for making this change. What existing problem does the pull request solve?
- It's sometimes necessary to pass an integer as a value for an attribute. In particular `colspan` for `<td>` elements. Currently, this value must be converted to a string BEFORE being passed to `add_attributes()`

**Documentation Update (required)**
- none

**How to review this PR**
- [ ] Edit any component and assign some test attrbitues to a variable:  Note - we are passing an integer value directly to `colspan` and a boolean/string/integer multivalue via an array to `data-test-attribute` - The result of the boolean value should be `1`
```
{% set test_attributes = test_attributes|default({
  'colspan': 3,
  'data-test-attribute': [TRUE, 'string', 123],
}) %}
```

- [ ] Call the `add_attributes` function on an element within a Drupal twig template
```
<div {{ add_attributes(test_attributes) }}></div>
```
- [ ] Inspect the markup and verify the above attributes are being properly rendered 


**Closing issues**
https://github.com/emulsify-ds/emulsify-twig-extensions/issues/4
