### PR TITLE
Excludes data-uuid attribute from being removed

### DIFF
--- a/src/BemTwigExtension.php
+++ b/src/BemTwigExtension.php
@@ -106,7 +106,11 @@ class BemTwigExtension extends \Twig_Extension {
           }
           // Remove the attribute from context so it doesn't trickle down to
           // includes.
-          $context['attributes']->removeAttribute($key);
+          // Do not remove data-uuid attribute as it will break layout
+          // paragraphs builder.
+          if (!$context['attributes']->hasAttribute('data-uuid')) {
+            $context['attributes']->removeAttribute($key);
+          }
         }
         // Add class attribute.
         if (!empty($classes)) {


### PR DESCRIPTION
**Summary**

This will exclude the 'data-uuid' attribute from being removed. If that attribute was removed and there is no ```{{ attributes }}``` in the outer paragraph div in the paragraph template, it would break the front-end [layout paragraphs builder](https://www.drupal.org/project/layout_paragraphs) interface, not allowing content editors to edit the paragraph on the front-end.

This PR fixes/implements the following **bugs/features**

- Fixes layout paragraphs builder - allowing content editors to edit a paragraph on the front-end

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

If the 'data-uuid' attribute was removed and there is no outer div around a paragraph with ```{{ attributes }}```, layout paragraphs builder would not show an edit button for that specific paragraph. If the 'data-uuid' attribute exits, this edit button will show.

**Documentation Update (required)**

None to existing documentation.

**How to review this PR**
- [ ] Install layout paragraphs (https://www.drupal.org/project/layout_paragraphs)
- [ ] In the twig template for a specific paragraph, remove the outer div that has ```{{ attributes }}```
- [ ] Clear cache
- [ ] Set the display for the default on a Paragraphs field to "Layout Paragraphs Builder (Experimental)
- [ ] View a node with paragraphs on the front-end, hover over one of the paragraphs and click "Edit Content Button"
- [ ] Hover over the paragraph item (which template was edited above), and verify that there is an hover/edit/delete area on the top left that displays. See screenshots.

**Screenshots**
<img width="215" alt="Screen Shot 2022-10-06 at 10 59 53 AM" src="https://user-images.githubusercontent.com/107938318/194386336-b6376786-3b7c-473c-888a-e6ced81be58d.png">
<img width="405" alt="Screen Shot 2022-10-06 at 10 59 44 AM" src="https://user-images.githubusercontent.com/107938318/194386353-286731e5-629e-4d9c-b940-0c6683a13468.png">

